### PR TITLE
Bump uglify-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "reactify": "~1.1.1",
     "resource-embedder": "~0.2.2",
     "style-loader": "^0.13.1",
-    "uglify-js": "~2.4.23",
+    "uglify-js": "~>2.6.0",
     "webpack": "^1.12.15",
     "webpack-dev-server": "^1.14.1",
     "extract-text-webpack-plugin": "^1.0.1",


### PR DESCRIPTION
There is CVE-2015-8858 for uglify-js versions below 2.6.0.

This was detected and suggested by github [1].

[1] https://help.github.com/articles/about-security-alerts-for-vulnerable-dependencies/