### PR TITLE
Allow searching for global and release components

### DIFF
--- a/src/Browser.jsx
+++ b/src/Browser.jsx
@@ -8,6 +8,8 @@ var BootstrapTable = ReactBSTable.BootstrapTable;
 var TableHeaderColumn = ReactBSTable.TableHeaderColumn;
 var $ = require('jquery');
 
+var common = require('./common.jsx');
+
 module.exports = React.createClass({
     render: function () {
       var _this = this;
@@ -36,12 +38,12 @@ module.exports = React.createClass({
         if (c.component.release) {
           release = c.component.release;
           component = c.component.name;
-          url = url + "release-component-contacts/" + c.id + "/";
+          url = url + common.resources.releaseComponentContacts + c.id + "/";
         }
         else {
           release = "N/A";
           component = c.component;
-          url = url + 'global-component-contacts/' + c.id + "/";
+          url = url + common.resources.globalComponentContacts + c.id + "/";
         }
         if (c.contact.username) {
           contact = c.contact.username + " <" + c.contact.email + ">";

--- a/src/LoadForm.jsx
+++ b/src/LoadForm.jsx
@@ -11,6 +11,16 @@ var classNames = require('classnames');
 var Select = require('react-select');
 var $ = require('jquery');
 
+var common = require('./common.jsx');
+
+// Prepends item to array only if it's not present yet.
+function prependOption(array, value, label) {
+  var item = {value: value, label: label};
+  if ($.inArray(item, array) === -1) {
+    array.unshift(item);
+  }
+}
+
 module.exports = React.createClass({
   handleSubmit: function (e) {
     e.preventDefault();
@@ -21,39 +31,39 @@ module.exports = React.createClass({
     };
     this.props.onSubmit(data);
   },
+
   handleInputChange: function () {
     this.props.inputChange();
   },
+
   render: function () {
-    var rel = this.props.releases;
-    if ($.inArray("global", rel) < 0) {
-      rel.unshift("global");
-    }
-    if ($.inArray("all", rel) < 0) {
-      rel.unshift("all");
-    }
-    var releaseList = rel.map(function(release) {
+    var releaseList = this.props.releases.map(function(release) {
       return { 'value': release, 'label': release };
     });
-    var r = this.props.roles;
-    if ($.inArray("all", r) < 0) {
-      r.unshift("all");
-    }
-    var roleList = r.map(function(role) {
+    prependOption(releaseList, common.values.releaseAllRelease, common.labels.releaseAllRelease);
+    prependOption(releaseList, common.values.releaseAllGlobal, common.labels.releaseAllGlobal);
+    prependOption(releaseList, common.values.releaseAll, common.labels.releaseAll);
+
+    var roleList = this.props.roles.map(function(role) {
       return { 'value': role, 'label': role };
     });
+    prependOption(roleList, common.values.rolesAll, common.labels.rolesAll);
+
     var component = (this.props.params['component']) ? this.props.params['component']:"";
     $("#component").attr("value", component);
-    var initRelease = '';
-    if (this.props.resource == "global-component-contacts/") {
-      initRelease = 'global';
-    }
-    else if (this.props.params['release']) {
+
+    var initRelease = common.values.releaseAll;
+    if (this.props.resource == common.resources.globalComponentContacts) {
+      initRelease = common.values.releaseAllGlobal
+    } else if (this.props.params['release']) {
       initRelease = this.props.params['release'];
-    } else {
-      initRelease = 'all';
+    } else if (this.props.resource == common.resources.releaseComponentContacts) {
+      initRelease = common.values.releaseAllRelease;
     }
-    var initRole = (this.props.params['role']) ? this.props.params['role'] : 'all';
+
+    var initRole = (this.props.params['role'])
+          ? this.props.params['role']
+          : common.values.rolesAll;
     var release_spinning = this.props.release_spinning;
     var role_spinning =  this.props.role_spinning;
 

--- a/src/NewPane.jsx
+++ b/src/NewPane.jsx
@@ -5,6 +5,8 @@ var Select = require('react-select');
 import {Row, Col, Tab, Nav, NavItem, FormGroup, ControlLabel, FormControl, ButtonGroup, Button, Glyphicon, Alert, Fade} from 'react-bootstrap';
 var $ = require('jquery');
 
+var common = require('./common.jsx');
+
 module.exports = React.createClass({
   getInitialState: function() {
     return {
@@ -94,11 +96,11 @@ module.exports = React.createClass({
     data["role"] = row["role"];
     if (row["release"] == "global") {
       data["component"] = row["component"];
-      url = url + "global-component-contacts/";
+      url = url + common.resources.globalComponentContacts;
     }
     else {
       data["component"] = {"name": row["component"], "release": row["release"]};
-      url = url + "release-component-contacts/";
+      url = url + common.resources.releaseComponentContacts;
     }
     var arr = row["contact"].split("<");
     var name = arr[0].trim();

--- a/src/common.jsx
+++ b/src/common.jsx
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  // Texts for special release and role filters.
+  labels: {
+    releaseAll: '[All]',
+    releaseAllGlobal: '[All global]',
+    releaseAllRelease: '[All with release]',
+    rolesAll: '[All]',
+  },
+
+  // Request values for special release and role filters.
+  values: {
+    releaseAll: 'all',
+    releaseAllGlobal: 'global',
+    releaseAllRelease: 'release',
+    rolesAll: 'all',
+  },
+
+  // Resource names.
+  resources: {
+    allComponentContacts: 'all-component-contacts/',
+    globalComponentContacts: 'global-component-contacts/',
+    releaseComponentContacts: 'release-component-contacts/',
+  },
+}
+

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -14,6 +14,8 @@ var appHistory = useRouterHistory(createHashHistory)({ queryKey: false });
 var App = require('./app.jsx');
 var $ = require('jquery');
 
+var common = require('./common.jsx');
+
 var performSearch = function(nextState) {
   if (nextState.location.action === 'POP') {
     $('.wrapper').trigger({ 'type': 'historyChange', 'location': nextState.location });
@@ -32,8 +34,9 @@ var routeChange = function(prevState, nextState) {
 ReactDOM.render(
   <Router history={appHistory}>
     <Route path="/" component={ App } />
-    <Route path="/release-component-contacts/" component={ App } onChange={routeChange} onEnter={performSearch} onLeave={returntoInitState}/>
-    <Route path="/global-component-contacts/" component={ App } onChange={routeChange} onEnter={performSearch} onLeave={returntoInitState}/>
+    <Route path={"/" + common.resources.releaseComponentContacts} component={ App } onChange={routeChange} onEnter={performSearch} onLeave={returntoInitState}/>
+    <Route path={"/" + common.resources.globalComponentContacts} component={ App } onChange={routeChange} onEnter={performSearch} onLeave={returntoInitState}/>
+    <Route path={"/" + common.resources.allComponentContacts} component={ App } onChange={routeChange} onEnter={performSearch} onLeave={returntoInitState}/>
   </Router>,
   document.getElementById('app')
 );


### PR DESCRIPTION
Fixes behavior for 'release=all' requests.

Shows pages with items from 'global-component-contacts' resource first
and 'release-component-contacts' on remaining pages.

Last page with items from the first resource can contain few items from
second resource, but in this case these these few items will repeat on
the following page due to imprecision of paging (could be solved by
offsets instead of paging on PDC server side).

Labels for the special filters are more easy to understand:
- [All] (same label for filtering contacts)
- [All global]
- [All with release]

Common variables are now defined in "common.jsx" module.

JIRA: PDC-2015