### PR TITLE
Allow overriding visual look in server settings

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,3 +25,28 @@ If you did not install node module globally, you need to add
 
 If you met error 'Authorization Required', please open the server you configured and check if this connection is untrusted.
 If so, please add the exception in your browser.
+
+# Customization
+
+The `serversettings.json` can contain extra field that tweak the look of the
+UI. Available keys are:
+
+* `logo`: a URL to an image that will be inserted into the header; it will be
+  rendered 20px high
+* `customStyle`: a URL to a stylesheet that will be injected into the page and
+  can override anything
+
+Relative URLs will be resolved relatively to the location with
+`serversettings.json` file.
+
+Additionally, you can add links to related services to the header. Just add
+`links` key and set its value to a list of two-item lists. The first element in
+the inner list is a URL, the second is a link label.
+
+```json
+{
+    "links": [
+        ["https://google.com", "Google"]
+    ]
+}
+```

--- a/css/app.css
+++ b/css/app.css
@@ -7,24 +7,47 @@ html, body {
 h2 button {
     margin-left: 2em;
 }
-.navbar {
-    position: relative;
-    min-height: 42px;
-    height: 42px;
-    margin-bottom: 0px;
-    margin-left: -20px;
-    border: 1px solid transparent;
-    border-top: 2px solid #cc0000;
-    width:calc(100% + 40px);
+/* menu text color */
+.navbar-default .navbar-nav > li > a {
+    color: #ffffff !important;
+}
+.navbar-default .navbar-nav > li > a:hover {
+    color: #cccccc !important;
 }
 .navbar-brand {
-    position: absolute;
-    left: 20px;
-    padding: 10px 40px;
-    font-size: 18px;
-    line-height: 20px;
-    height: 40px;
+    font-weight: bold !important;
 }
+.navbar-brand img {
+    height: 20px !important;
+    float: left !important;
+    margin-right: 0.5em !important;
+}
+.navbar-utility li a {
+    border-left: 0px !important;
+    /* fix 1px red line under user menu */
+    height: 26px !important;
+}
+.navbar-pf .navbar-brand {
+    padding-top: 3px !important;
+    padding-bottom: 3px !important;
+}
+/* shrink collapsed menu a bit in order not to resize header bar */
+.navbar-header .navbar-toggle {
+    padding-top: 7px !important;
+    padding-bottom: 5px !important;
+}
+/* fix padding for navbar-utility collapsed menu */
+.navbar-utility li.dropdown a.dropdown-toggle {
+    padding-left: 20px !important;
+}
+/* fix icon placement for navbar-utility collapsed menu */
+.navbar-utility span.fa, .navbar-utility span.pficon {
+    width: 12px !important;
+    position: relative !important;
+    top: 0px !important;
+    left: 0px !important;
+}
+
 .form-control{
   height: 30px;
 }

--- a/css/app.css
+++ b/css/app.css
@@ -20,7 +20,7 @@ h2 button {
 .navbar-brand {
     position: absolute;
     left: 20px;
-    padding: 10px 20px;
+    padding: 10px 40px;
     font-size: 18px;
     line-height: 20px;
     height: 40px;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-react": "^6.5.0",
     "browserify": "~10.2.4",
     "css-loader": "^0.23.1",
+    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "postcss-loader": "^0.9.1",
     "precss": "^1.4.0",
@@ -42,11 +43,11 @@
     "react-tools": ">=0.13.3",
     "reactify": "~1.1.1",
     "resource-embedder": "~0.2.2",
+    "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
     "uglify-js": "~>2.6.0",
+    "url-loader": "^0.6.2",
     "webpack": "^1.12.15",
-    "webpack-dev-server": "^1.14.1",
-    "extract-text-webpack-plugin": "^1.0.1",
-    "rimraf": "^2.5.2"
+    "webpack-dev-server": "^1.14.1"
   }
 }

--- a/src/HeaderLinks.jsx
+++ b/src/HeaderLinks.jsx
@@ -1,0 +1,35 @@
+'use strict';
+
+var React = require('react');
+var ReactDOM = require('react-dom');
+var ReactBootstrap = require('react-bootstrap');
+var Dropdown = ReactBootstrap.Dropdown;
+var MenuItem = ReactBootstrap.MenuItem;
+
+var common = require('./common.jsx');
+
+module.exports = React.createClass({
+    render: function () {
+        if (!this.props.links) {
+            return null;
+        }
+
+        var links = this.props.links.map(function (item) {
+            return (<MenuItem key={item[0]} href={item[0]}>{item[1]}</MenuItem>);
+        });
+
+        return (
+            <ul className="nav navbar-nav navbar-utility">
+                <Dropdown componentClass="li" id="header-links">
+                    <Dropdown.Toggle useAnchor>
+                        <span className="fa fa-star"></span>
+                        Links
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu>
+                        {links}
+                    </Dropdown.Menu>
+                </Dropdown>
+            </ul>
+        );
+    }
+});

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -13,6 +13,7 @@ var LoadForm = require('./LoadForm.jsx');
 var TableToolbar = require('./TableToolbar.jsx');
 var Browser = require('./Browser.jsx');
 var Pager = require('./Pager.jsx');
+var HeaderLinks = require('./HeaderLinks.jsx');
 var NetworkErrorDialog = require('./NetworkErrorDialog.jsx');
 var classNames = require('classnames');
 
@@ -168,6 +169,7 @@ module.exports = React.createClass({
       selectedContact: {},
       logo: null,
       customStyle: null,
+      links: [],
     };
   },
   componentDidMount: function() {
@@ -182,6 +184,7 @@ module.exports = React.createClass({
       localStorage.setItem('server', data['server']);
       self.state.logo = data['logo'] || null;
       self.state.customStyle = data['customStyle'] || null;
+      self.state.links = data.links;
       self.state.url = data['server'];
       handleData();
     });
@@ -448,6 +451,7 @@ module.exports = React.createClass({
                 Product Definition Center &mdash; Contact Browser
               </Navbar.Brand>
             </Navbar.Header>
+            <HeaderLinks links={this.state.links} />
           </Navbar>
           <div className="container-fluid wrapper">
             <Row className="layout">

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -444,15 +444,20 @@ module.exports = React.createClass({
       return (
         <div>
           {style}
-          <Navbar fluid inverse>
+          <nav className="navbar navbar-pf navbar-default">
             <Navbar.Header>
               <Navbar.Brand>
                 {logo}
                 Product Definition Center &mdash; Contact Browser
               </Navbar.Brand>
             </Navbar.Header>
-            <HeaderLinks links={this.state.links} />
-          </Navbar>
+            <div className="navbar-collapse collapse">
+                <HeaderLinks links={this.state.links} />
+                <ul className="nav navbar-nav navbar-primary">
+                    <li><a href="/">Contact Browser</a></li>
+                </ul>
+            </div>
+          </nav>
           <div className="container-fluid wrapper">
             <Row className="layout">
               <Col md={3} className="leftCol">

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -165,7 +165,9 @@ module.exports = React.createClass({
       contact_spinning: contact_spinning,
       root: root,
       resource: resource,
-      selectedContact: {}
+      selectedContact: {},
+      logo: null,
+      customStyle: null,
     };
   },
   componentDidMount: function() {
@@ -178,6 +180,8 @@ module.exports = React.createClass({
     });
     $.getJSON("serversetting.json", function( data ) {
       localStorage.setItem('server', data['server']);
+      self.state.logo = data['logo'] || null;
+      self.state.customStyle = data['customStyle'] || null;
       self.state.url = data['server'];
       handleData();
     });
@@ -426,31 +430,43 @@ module.exports = React.createClass({
         'hidden': !this.state.busy,
         'global-spin': !this.state.showresult
       });
+      var logo = null;
+      var style = null;
+      if (this.state.logo) {
+          logo = <img src={this.state.logo} className="brand-logo" />;
+      }
+      if (this.state.customStyle) {
+          style = <link rel="stylesheet" type="text/css" href={this.state.customStyle} />;
+      }
       return (
-        <div className="container-fluid wrapper">
-          <Navbar inverse>
+        <div>
+          {style}
+          <Navbar fluid inverse>
             <Navbar.Header>
               <Navbar.Brand>
-                Contact Browser
+                {logo}
+                Product Definition Center &mdash; Contact Browser
               </Navbar.Brand>
             </Navbar.Header>
           </Navbar>
-          <Row className="layout">
-            <Col md={3} className="leftCol">
-              <LoadForm releases={this.state.releases} roles={this.state.roles} contacts={this.state.contacts} release_spinning={this.state.release_spinning} role_spinning={this.state.role_spinning} contact_spinning={this.state.contact_spinning} params={this.state.params} resource={this.state.resource} onSubmit={this.handleFormSubmit} inputChange={this.handleInputChange}/>
-            </Col>
-            <Col md={9} className="rightCol">
-              <TableToolbar showresult={this.state.showresult} releases={this.state.releases} roles={this.state.roles} contacts={this.state.contacts}
-                selectedContact={this.state.selectedContact} clearSelectedContact={this.clearSelectedContact}/>
-              <div id="browser-wrapper">
-                <i className={browserSpinnerClass}></i>
-                <Browser id="erer" data={this.state.data} showresult={this.state.showresult} onSelectContact={this.onSelectContact}/>
-              </div>
-              <Pager count={this.state.count} showresult={this.state.showresult} page={this.state.page} page_size={this.state.page_size} onPageChange={this.handlePageChange} reloadPage={this.loadData} />
-            </Col>
-          </Row>
-          <div className={overlayClass}></div>
-          <NetworkErrorDialog ref='errorDialog' data={this.state.error} />
+          <div className="container-fluid wrapper">
+            <Row className="layout">
+              <Col md={3} className="leftCol">
+                <LoadForm releases={this.state.releases} roles={this.state.roles} contacts={this.state.contacts} release_spinning={this.state.release_spinning} role_spinning={this.state.role_spinning} contact_spinning={this.state.contact_spinning} params={this.state.params} resource={this.state.resource} onSubmit={this.handleFormSubmit} inputChange={this.handleInputChange}/>
+              </Col>
+              <Col md={9} className="rightCol">
+                <TableToolbar showresult={this.state.showresult} releases={this.state.releases} roles={this.state.roles} contacts={this.state.contacts}
+                  selectedContact={this.state.selectedContact} clearSelectedContact={this.clearSelectedContact}/>
+                <div id="browser-wrapper">
+                  <i className={browserSpinnerClass}></i>
+                  <Browser id="erer" data={this.state.data} showresult={this.state.showresult} onSelectContact={this.onSelectContact}/>
+                </div>
+                <Pager count={this.state.count} showresult={this.state.showresult} page={this.state.page} page_size={this.state.page_size} onPageChange={this.handlePageChange} reloadPage={this.loadData} />
+              </Col>
+            </Row>
+            <div className={overlayClass}></div>
+            <NetworkErrorDialog ref='errorDialog' data={this.state.error} />
+          </div>
         </div>
       );
     }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,7 @@
-require('patternfly/dist/css/patternfly.css');
 require('react-bootstrap-table/css/react-bootstrap-table.css');
 require('react-select/dist/react-select.css');
+require('patternfly/dist/css/patternfly.css');
+require('patternfly/dist/css/patternfly-additions.css');
 require('./../css/app.css');
 
 var React = require('react');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
       { test: /\.jsx$/, loaders: ['react-hot', 'babel'], include: path.join(__dirname, 'src') },
       { test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader') },
       { test: /\.png$/, loader: 'url-loader?limit=100000&name=img/[name].[ext]' },
+      { test: /\.gif$/, loader: 'url-loader?limit=100000&name=img/[name].[ext]' },
       { test: /\.jpg$/, loader: 'file-loader?name=img/[name].[ext]' },
       { test: /\.(ttf|eot|svg|woff(2)?)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'file-loader?name=fonts/[name].[ext]' }
     ]


### PR DESCRIPTION
Two new keys can be specified in the server settings JSON file.

 * logo - a path to image file that should be added to header
 * customStyle - a path to stylesheet that should be included on the page

There should be no change in how the UI looks, but it should allow us to customize it to match header of our PDC instance. See `redhat-style` branch in my fork for how that could be done.