### PR TITLE
Fix webpack prod config

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -27,6 +27,7 @@ module.exports = {
       { test: /\.jsx$/, loaders: ['babel'], include: path.join(__dirname, 'src') },
       { test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader') },
       { test: /\.png$/, loader: 'url-loader?limit=100000&name=img/[name].[ext]' },
+      { test: /\.gif$/, loader: 'url-loader?limit=100000&name=img/[name].[ext]' },
       { test: /\.jpg$/, loader: 'file-loader?name=img/[name].[ext]' },
       { test: /\.(ttf|eot|svg|woff(2)?)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'file-loader?name=fonts/[name].[ext]' }
     ]


### PR DESCRIPTION
We need to tell it how to handle GIF files - they should be encoded into data URI.

The same change is done in the other config, but not in the production one used by `npm run build:webpack`.